### PR TITLE
Fix: improve snapshot file name handling by using TrimSuffix for file extensions

### DIFF
--- a/pkg/charts/snap.go
+++ b/pkg/charts/snap.go
@@ -306,8 +306,8 @@ func defaultSnapshotFilePath(chartPath, valuesFile string) string {
 func snapshotFileName(valuesFile string) string {
 	if valuesFile != "" {
 		name := path.Base(valuesFile)
-		name = strings.ReplaceAll(name, ".yaml", "")
-		name = strings.ReplaceAll(name, ".yml", "")
+		name = strings.TrimSuffix(name, ".yaml")
+		name = strings.TrimSuffix(name, ".yml")
 		return name
 	} else {
 		return "default"


### PR DESCRIPTION
This pull request includes a minor optimization to the `snapshotFileName` function in the `pkg/charts/snap.go` file. The change replaces the use of `strings.ReplaceAll` with `strings.TrimSuffix` for removing file extensions, improving code clarity and efficiency.

* **Code optimization:**
  * [`pkg/charts/snap.go`](diffhunk://#diff-3a617ea64e868e55e6fd3b59eee7fca908d712f39901ca0d016da40582df90d0L309-R310): Updated the `snapshotFileName` function to use `strings.TrimSuffix` instead of `strings.ReplaceAll` for removing `.yaml` and `.yml` file extensions. This change simplifies the logic and avoids unnecessary replacements.