### PR TITLE
Revert #189

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -8,4 +8,4 @@ command: "$HELM_PLUGIN_DIR/bin/chartsnap"
 ignoreFlags: false
 hooks:
   install: "cd $HELM_PLUGIN_DIR; scripts/install_plugin.sh"
-  update: "cd $HELM_PLUGIN_DIR; scripts/install_plugin.sh -u"
+  update: "cd $HELM_PLUGIN_DIR; scripts/install_plugin.sh"

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -54,20 +54,7 @@ if [ -n "$HELM_PUSH_PLUGIN_NO_INSTALL_HOOK" ]; then
     exit 0
 fi
 
-# If update flag is provided, git checkout the latest tag
-if [ "$1" = "-u" ]; then
-    echo "Updating ${name} plugin..."
-    before_version=$(get_plugin_version)
-    git fetch 2>/dev/null
-    git pull 2>/dev/null
-    
-    latest_version=$(get_plugin_version)
-    if [ "$before_version" = "$latest_version" ]; then
-        echo "${name} is already up to date (${latest_version})."
-        exit 0
-    fi
-fi
-
+# Autodetect the latest version
 version=$(get_plugin_version)
 echo "Downloading and installing ${name} v${version} ..."
 


### PR DESCRIPTION
Revert #189

When helm plugin update, plugin dir git repo seems to be automatically updated..

```sh
❯ helm plugin update chartsnap --debug
plugin_update.go:65: 2025-05-29 00:44:43.947442 +0900 JST m=+0.134082084 [debug] loading installed plugins from /Users/jlandowner/Library/helm/plugins
[debug] vcs_installer.go:97: updating https://github.com/jlandowner/helm-chartsnap
plugin_update.go:107: 2025-05-29 00:44:46.063699 +0900 JST m=+2.250327209 [debug] loading plugin from /Users/jlandowner/Library/helm/plugins/helm-chartsnap
plugin.go:69: 2025-05-29 00:44:46.069075 +0900 JST m=+2.255702543 [debug] running update hook: /bin/sh -c cd $HELM_PLUGIN_DIR; scripts/install_plugin.sh -u
```