### PR TITLE
feat: Support user-provided fixed value for dynamic fields

### DIFF
--- a/pkg/unstructured/unstructured.go
+++ b/pkg/unstructured/unstructured.go
@@ -95,8 +95,12 @@ func ApplyFixedValue(t v1alpha1.SnapshotConfig, manifests []metaV1.Unstructured)
 			if v.APIVersion == obj.GetAPIVersion() &&
 				v.Kind == obj.GetKind() &&
 				v.Name == obj.GetName() {
-				for _, p := range v.JSONPath {
-					newObj, err := Replace(manifests[i], p, v.DynamicValue())
+				for _, p := range v.JSONPath { // p is now a JSONPathItem
+					valueToApply := v.DynamicValue() // Default to existing dynamic placeholder
+					if p.Value != "" {
+						valueToApply = p.Value
+					}
+					newObj, err := Replace(manifests[i], p.Path, valueToApply)
 					if err != nil {
 						return fmt.Errorf("failed to replace json path: %w", err)
 					}

--- a/pkg/unstructured/unstructured_test.go
+++ b/pkg/unstructured/unstructured_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme" // Required for DeepCopy
+	"github.com/stretchr/testify/assert"
+	"github.com/jlandowner/helm-chartsnap/pkg/api/v1alpha1"
 )
 
 func TestEncode(t *testing.T) {
@@ -62,6 +65,183 @@ metadata:
 			}
 			if string(got) != tt.want {
 				t.Errorf("Encode() = %s, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newTestUnstructuredConfigMap(name string, data map[string]interface{}) *metaV1.Unstructured {
+	return &metaV1.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+			"data": data,
+		},
+	}
+}
+
+func TestApplyFixedValue(t *testing.T) {
+	tests := []struct {
+		name              string
+		initialManifests  []metaV1.Unstructured
+		config            v1alpha1.SnapshotConfig
+		expectedManifests []metaV1.Unstructured // For full object comparison if needed, or use expectedFields
+		expectedFields    map[int]map[string]string // map[manifestIndex]map[jsonPath]expectedValue
+		wantErr           bool
+	}{
+		{
+			name: "Scenario 1: JSONPathList with paths only",
+			initialManifests: []metaV1.Unstructured{
+				*newTestUnstructuredConfigMap("my-cm", map[string]interface{}{"key1": "value1", "key2": "value2"}),
+			},
+			config: v1alpha1.SnapshotConfig{
+				DynamicFields: []v1alpha1.ManifestPath{
+					{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+						Name:       "my-cm",
+						JSONPath: v1alpha1.JSONPathList{
+							{Path: "/data/key1"},
+							{Path: "/metadata/name"},
+						},
+					},
+				},
+			},
+			expectedFields: map[int]map[string]string{
+				0: {
+					"/data/key1":     v1alpha1.DynamicValue,
+					"/metadata/name": v1alpha1.DynamicValue,
+				},
+			},
+		},
+		{
+			name: "Scenario 1.1: JSONPathList with paths only and Base64",
+			initialManifests: []metaV1.Unstructured{
+				*newTestUnstructuredConfigMap("my-secret", map[string]interface{}{"secretKey": "c2VjcmV0VmFsdWU="}), // Assume data is already base64 encoded as per k8s
+			},
+			config: v1alpha1.SnapshotConfig{
+				DynamicFields: []v1alpha1.ManifestPath{
+					{
+						APIVersion: "v1",
+						Kind:       "ConfigMap", // Testing with ConfigMap for simplicity, field would be stringData for Secret
+						Name:       "my-secret",
+						Base64:     true,
+						JSONPath: v1alpha1.JSONPathList{
+							{Path: "/data/secretKey"},
+						},
+					},
+				},
+			},
+			expectedFields: map[int]map[string]string{
+				0: {
+					"/data/secretKey": v1alpha1.Base64DynamicValue,
+				},
+			},
+		},
+		{
+			name: "Scenario 2: JSONPathList with paths and values",
+			initialManifests: []metaV1.Unstructured{
+				*newTestUnstructuredConfigMap("my-cm-paths-values", map[string]interface{}{"key1": "value1", "key2": "value2"}),
+			},
+			config: v1alpha1.SnapshotConfig{
+				DynamicFields: []v1alpha1.ManifestPath{
+					{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+						Name:       "my-cm-paths-values",
+						JSONPath: v1alpha1.JSONPathList{
+							{Path: "/data/key1", Value: "fixed-value1"},
+							{Path: "/metadata/name", Value: "fixed-name-cm"},
+						},
+					},
+				},
+			},
+			expectedFields: map[int]map[string]string{
+				0: {
+					"/data/key1":     "fixed-value1",
+					"/metadata/name": "fixed-name-cm",
+				},
+			},
+		},
+		{
+			name: "Scenario 3: JSONPathList with mixed paths-only and paths-with-values",
+			initialManifests: []metaV1.Unstructured{
+				*newTestUnstructuredConfigMap("my-cm-mixed", map[string]interface{}{"key1": "value1", "key2": "value2", "key3": "value3"}),
+			},
+			config: v1alpha1.SnapshotConfig{
+				DynamicFields: []v1alpha1.ManifestPath{
+					{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+						Name:       "my-cm-mixed",
+						JSONPath: v1alpha1.JSONPathList{
+							{Path: "/data/key1", Value: "fixed-value-mixed"},
+							{Path: "/data/key2"}, // Fallback to DynamicValue
+							{Path: "/metadata/name", Value: "fixed-name-mixed-cm"},
+						},
+					},
+				},
+			},
+			expectedFields: map[int]map[string]string{
+				0: {
+					"/data/key1":     "fixed-value-mixed",
+					"/data/key2":     v1alpha1.DynamicValue,
+					"/metadata/name": "fixed-name-mixed-cm",
+				},
+			},
+		},
+		{
+			name: "No matching manifest",
+			initialManifests: []metaV1.Unstructured{
+				*newTestUnstructuredConfigMap("another-cm", map[string]interface{}{"key1": "value1"}),
+			},
+			config: v1alpha1.SnapshotConfig{
+				DynamicFields: []v1alpha1.ManifestPath{
+					{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+						Name:       "non-existent-cm", // This name does not match
+						JSONPath: v1alpha1.JSONPathList{
+							{Path: "/data/key1", Value: "should-not-apply"},
+						},
+					},
+				},
+			},
+			expectedFields: map[int]map[string]string{
+				0: { // Original values should remain
+					"/data/key1":     "value1",
+					"/metadata/name": "another-cm",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Deep copy initial manifests to avoid modification across test cases
+			currentManifests := make([]metaV1.Unstructured, len(tt.initialManifests))
+			for i, m := range tt.initialManifests {
+				currentManifests[i] = *m.DeepCopyObject().(*metaV1.Unstructured)
+			}
+
+			err := ApplyFixedValue(tt.config, currentManifests)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				for i, expectedFieldsForManifest := range tt.expectedFields {
+					manifest := currentManifests[i]
+					for jsonPath, expectedValue := range expectedFieldsForManifest {
+						pathParts := strings.Split(strings.TrimPrefix(jsonPath, "/"), "/")
+						actualValue, found, _ := metaV1.NestedString(manifest.Object, pathParts...)
+						assert.True(t, found, "Path %s not found in manifest %d", jsonPath, i)
+						assert.Equal(t, expectedValue, actualValue, "Value mismatch for path %s in manifest %d", jsonPath, i)
+					}
+				}
 			}
 		})
 	}

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -74,8 +74,12 @@ func ApplyFixedValueToDynamicFieleds(t v1alpha1.SnapshotConfig, docs []*yaml.RNo
 			if v.APIVersion == doc.GetApiVersion() &&
 				v.Kind == doc.GetKind() &&
 				v.Name == doc.GetName() {
-				for _, p := range v.JSONPath {
-					err := Replace(docs[i], p, v.DynamicValue())
+				for _, p := range v.JSONPath { // p is a v1alpha1.JSONPathItem
+					valueToApply := v.DynamicValue() // Default to existing dynamic placeholder
+					if p.Value != "" {
+						valueToApply = p.Value
+					}
+					err := Replace(docs[i], p.Path, valueToApply)
 					if err != nil {
 						return fmt.Errorf("failed to replace json path: %w", err)
 					}


### PR DESCRIPTION
Close #105 

This change enhances the dynamicFields feature to allow you to specify a fixed 'value' for a given 'jsonPath', in addition to extracting it from a Kubernetes resource.

The `jsonPath` field in `dynamicFields` now supports two formats for backward compatibility:
1. A list of strings (existing behavior): `jsonPath: ["/data/key1", "/spec/replica"]` In this case, the fields will be replaced by a placeholder dynamic value.
2. A list of objects (new behavior): ```yaml jsonPath: - path: /data/key1 value: "my-fixed-value" - path: /spec/replica value: "3" - path: /data/another_key # No value, will use placeholder ```

Changes include:
- Introduced `JSONPathItem` and `JSONPathList` types in `pkg/api/v1alpha1/testspec.go`.
- Implemented custom YAML unmarshaling for `JSONPathList` to handle both string and object array inputs.
- Updated `ApplyFixedValue` in `pkg/unstructured/unstructured.go` and `ApplyFixedValueToDynamicFieleds` in `pkg/yaml/yaml.go` to process the new structure, using the provided `value` if present, otherwise falling back to the dynamic placeholder.
- Added comprehensive unit tests for the new unmarshaling logic and the updated value application in both unstructured and YAML processing paths.