### PR TITLE
feat: Option to Ignore Output Order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ integ-test: install-dev-bin
 	helm chartsnap --chart example/app1 -f example/app1/test_v2/ --namespace default $(ARGS)
 	helm chartsnap --chart example/app1 -f example/app1/test_v3/ --namespace default $(ARGS)
 	helm chartsnap --chart example/app1 -f example/app1/test_wildcard/ --namespace default $(ARGS)
+	helm chartsnap --chart example/app1 -f example/app1/test_order/ --namespace default $(ARGS) && diff example/app1/test_order/__snapshots__/test_order_a.snap example/app1/test_order/__snapshots__/test_order_b.snap
 	helm chartsnap --chart oci://ghcr.io/nginxinc/charts/nginx-gateway-fabric -f example/remote/nginx-gateway-fabric.values.yaml $(ARGS) -- --namespace nginx-gateway $(EXTRA_ARGS)
 	helm chartsnap --chart cilium -f example/remote/cilium.values.yaml $(ARGS) -- --namespace kube-system --repo https://helm.cilium.io $(EXTRA_ARGS)
 	helm chartsnap --chart ingress-nginx -f example/remote/ingress-nginx.values.yaml $(ARGS) -- --repo https://kubernetes.github.io/ingress-nginx --namespace ingress-nginx --skip-tests $(EXTRA_ARGS)

--- a/example/app1/templates/configmap.yaml
+++ b/example/app1/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- range .Values.configMaps }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "app1.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "app1.labels" $ | nindent 4 }}
+data:
+  {{- range .data }}
+  {{ .key }}: {{ .value | quote }}
+  {{- end }}
+{{- end }}

--- a/example/app1/test_order/.chartsnap.yaml
+++ b/example/app1/test_order/.chartsnap.yaml
@@ -1,0 +1,11 @@
+# This file defines common behavior of the chart snapshots in the test directory.
+ignoreOrder: true
+dynamicFields:
+  - apiVersion: v1
+    kind: Secret
+    name: app1-cert
+    jsonPath:
+      - /data/ca.crt
+      - /data/tls.crt
+      - /data/tls.key
+    base64: true

--- a/example/app1/test_order/__snapshots__/test_order_a.snap
+++ b/example/app1/test_order/__snapshots__/test_order_a.snap
@@ -1,0 +1,165 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: app1/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-app1
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app1
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: app1-0.1.0
+        app.kubernetes.io/name: app1
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: chartsnap-app1
+      securityContext: {}
+      containers:
+      - name: app1
+        securityContext: {}
+        image: "nginx:1.16.0"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+        resources: {}
+---
+# Source: app1/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-app1-alpha
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  LOG_LEVEL: "info"
+  REGION: "us-east-1"
+---
+# Source: app1/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-app1-beta
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TIMEOUT: "30"
+---
+# Source: app1/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-app1-gamma
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  FEATURE_FLAG: "true"
+---
+# Source: app1/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-app1-test-connection"
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: wget
+    image: busybox
+    command: ['wget']
+    args: ['chartsnap-app1:80']
+  restartPolicy: Never
+---
+# Source: app1/templates/cert.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app1-cert
+  namespace: default
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/tls
+data:
+  ca.crt: IyMjRFlOQU1JQ19GSUVMRCMjIw==
+  tls.crt: IyMjRFlOQU1JQ19GSUVMRCMjIw==
+  tls.key: IyMjRFlOQU1JQ19GSUVMRCMjIw==
+---
+# Source: app1/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-app1
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: app1/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-app1
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true

--- a/example/app1/test_order/__snapshots__/test_order_b.snap
+++ b/example/app1/test_order/__snapshots__/test_order_b.snap
@@ -1,0 +1,165 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: app1/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-app1
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app1
+      app.kubernetes.io/instance: chartsnap
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: app1-0.1.0
+        app.kubernetes.io/name: app1
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: chartsnap-app1
+      securityContext: {}
+      containers:
+      - name: app1
+        securityContext: {}
+        image: "nginx:1.16.0"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+        resources: {}
+---
+# Source: app1/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-app1-alpha
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  LOG_LEVEL: "info"
+  REGION: "us-east-1"
+---
+# Source: app1/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-app1-beta
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  TIMEOUT: "30"
+---
+# Source: app1/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-app1-gamma
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  FEATURE_FLAG: "true"
+---
+# Source: app1/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "chartsnap-app1-test-connection"
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: wget
+    image: busybox
+    command: ['wget']
+    args: ['chartsnap-app1:80']
+  restartPolicy: Never
+---
+# Source: app1/templates/cert.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app1-cert
+  namespace: default
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+type: kubernetes.io/tls
+data:
+  ca.crt: IyMjRFlOQU1JQ19GSUVMRCMjIw==
+  tls.crt: IyMjRFlOQU1JQ19GSUVMRCMjIw==
+  tls.key: IyMjRFlOQU1JQ19GSUVMRCMjIw==
+---
+# Source: app1/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-app1
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+---
+# Source: app1/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-app1
+  labels:
+    helm.sh/chart: app1-0.1.0
+    app.kubernetes.io/name: app1
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true

--- a/example/app1/test_order/test_order_a.yaml
+++ b/example/app1/test_order/test_order_a.yaml
@@ -1,0 +1,15 @@
+configMaps:
+  - name: alpha
+    data:
+      - key: LOG_LEVEL
+        value: info
+      - key: REGION
+        value: us-east-1
+  - name: beta
+    data:
+      - key: TIMEOUT
+        value: "30"
+  - name: gamma
+    data:
+      - key: FEATURE_FLAG
+        value: "true"

--- a/example/app1/test_order/test_order_b.yaml
+++ b/example/app1/test_order/test_order_b.yaml
@@ -1,0 +1,16 @@
+# Same ConfigMaps as test_order_a.yaml but in different order — snapshots are sorted so both produce identical output.
+configMaps:
+  - name: gamma
+    data:
+      - key: FEATURE_FLAG
+        value: "true"
+  - name: alpha
+    data:
+      - key: LOG_LEVEL
+        value: info
+      - key: REGION
+        value: us-east-1
+  - name: beta
+    data:
+      - key: TIMEOUT
+        value: "30"

--- a/example/app1/values.yaml
+++ b/example/app1/values.yaml
@@ -105,3 +105,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+configMaps: []
+# - name: app-config
+#   data:
+#     - key: LOG_LEVEL
+#       value: info

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ type option struct {
 	SnapshotVersion  string
 	FailHelmError    bool
 	SnapshotFileExt  string
+	IgnoreOrder      bool
 
 	// Below properties are the same as helm global options
 	// They are passed to the plugin as environment variables
@@ -98,6 +99,9 @@ func (o *option) overrideSnapshotConfig(cfg *v1alpha1.SnapshotConfig) {
 	}
 	if o.snapshotVersion() != "" {
 		cfg.SnapshotVersion = o.snapshotVersion()
+	}
+	if o.IgnoreOrder {
+		cfg.IgnoreOrder = true
 	}
 }
 
@@ -204,6 +208,7 @@ MIT 2023 jlandowner/helm-chartsnap
 	rootCmd.PersistentFlags().StringVar(&o.SnapshotVersion, "snapshot-version", "", "use a specific snapshot format version. v1, v2, v3 are supported. (default: latest)")
 	rootCmd.PersistentFlags().StringVar(&o.SnapshotFileExt, "snapshot-file-ext", "", `snapshot file extension. default is ".snap" and if set "yaml", ".snap.yaml" is used`)
 	rootCmd.PersistentFlags().BoolVar(&o.FailHelmError, "fail-helm-error", false, "fail if 'helm template' command failed")
+	rootCmd.PersistentFlags().BoolVar(&o.IgnoreOrder, "ignore-order", false, "ignore resource ordering by sorting resources by APIVersion, Kind, and Name before snapshotting")
 }
 
 func main() {

--- a/pkg/api/v1alpha1/testspec.go
+++ b/pkg/api/v1alpha1/testspec.go
@@ -30,6 +30,7 @@ type SnapshotConfig struct {
 	DynamicFields   []ManifestPath `yaml:"dynamicFields,omitempty"`
 	SnapshotFileExt string         `yaml:"snapshotFileExt,omitempty"`
 	SnapshotVersion string         `yaml:"snapshotVersion,omitempty"`
+	IgnoreOrder      bool           `yaml:"ignoreOrder,omitempty"`
 }
 
 type ManifestPath struct {
@@ -67,5 +68,8 @@ func (t *SnapshotConfig) Merge(cfg SnapshotConfig) {
 	}
 	if cfg.SnapshotVersion != "" {
 		t.SnapshotVersion = cfg.SnapshotVersion
+	}
+	if cfg.IgnoreOrder {
+		t.IgnoreOrder = true
 	}
 }

--- a/pkg/charts/snap.go
+++ b/pkg/charts/snap.go
@@ -269,6 +269,10 @@ func (o *ChartSnapshotter) snapV3(cfg v1alpha1.SnapshotConfig, data []byte) (res
 		return nil, fmt.Errorf("failed to replace json path: %w", err)
 	}
 
+	if cfg.IgnoreOrder {
+		yaml.SortResources(manifests)
+	}
+
 	raw, err := yaml.Encode(manifests)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode manifests: %w", err)

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"cmp"
+	"slices"
 	"strings"
 	"sync"
 
@@ -119,6 +121,17 @@ func convertToUnknownNode(docs []*yaml.RNode) error {
 		}
 	}
 	return nil
+}
+
+// SortResources sorts resources in-place by APIVersion, Kind, then Name
+func SortResources(resources []*yaml.RNode) {
+	slices.SortStableFunc(resources, func(a, b *yaml.RNode) int {
+		return cmp.Or(
+			cmp.Compare(a.GetApiVersion(), b.GetApiVersion()),
+			cmp.Compare(a.GetKind(), b.GetKind()),
+			cmp.Compare(a.GetName(), b.GetName()),
+		)
+	})
 }
 
 // Replace replaces the value at the given jsonpath with the given value.


### PR DESCRIPTION
Helm does not guarantee order in a `range` loop on map (https://github.com/helm/helm/issues/4375), this can lead to the outputted in different order causing a diff.

Apply ordering is better controlled using tools like [ArgoCD sync waves](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/).

This PR adds an option to sort all resources.
