### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   unittest:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -64,7 +64,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -77,6 +77,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   create-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -17,9 +19,18 @@ jobs:
           fetch-depth: 0
           ref: main
 
+      - name: Validate semver
+        run: |
+          if ! [[ "${SEMVER}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid semver: ${SEMVER}" >&2
+            exit 1
+          fi
+        env:
+          SEMVER: ${{ github.event.inputs.semver }}
+
       - name: Try to update inline versions
         run: |
-          make update-versions VERSION=${SEMVER}
+          make update-versions VERSION="${SEMVER}"
         env:
           SEMVER: ${{ github.event.inputs.semver }}
 
@@ -41,14 +52,16 @@ jobs:
 
       - name: Create tag
         run: |
-          git tag ${GIT_TAG}
-          git push origin ${GIT_TAG}
+          git tag "${GIT_TAG}"
+          git push origin "${GIT_TAG}"
         env:
           GIT_TAG: v${{ github.event.inputs.semver }}
 
   create-release:
     runs-on: ubuntu-latest
     needs: create-tag
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Set CI workflow token permissions to read-only contents access
- Scope release workflow token permissions to the jobs that need contents write
- Validate and quote release semver inputs before using them in shell commands
- Update CodeQL actions to v4 and enable Dependabot updates for GitHub Actions

## Verification
- Parsed workflow and Dependabot YAML with Ruby YAML loader
- Ran git diff --check for changed workflow files

Note: coverage.txt was already modified locally from a prior test run and is not included in this PR.