### PR TITLE
Install Helm v4 before unit tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,9 @@ jobs:
           go-version-file: go.mod
       - run: go version
 
+      - name: Install Helm v4
+        run: make helm
+
       - name: Unittest
         run: |
           make test GO=go


### PR DESCRIPTION
## Summary
- Install Helm v4 in the CI unittest job before running make test
- Align unittest with the integ-test job so remote chart snapshots render against the same Helm major version

## Verification
- Parsed .github/workflows/ci.yaml with Ruby YAML loader
- Ran git diff --check for .github/workflows/ci.yaml

Note: coverage.txt is still locally modified from test runs and is not included in this PR.